### PR TITLE
feat: make header bolder and add subheader

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -14,6 +14,7 @@
         <header>
             <h1>Course Materials Assistant</h1>
             <p class="subtitle">Ask questions about courses, instructors, and content</p>
+            <p class="subheader">Course materials ROCK!!</p>
             <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme" title="Toggle light/dark theme">
                 <svg class="theme-icon sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <circle cx="12" cy="12" r="5"/>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -134,7 +134,7 @@ header {
 
 header h1 {
     font-size: 1.75rem;
-    font-weight: 700;
+    font-weight: 900;
     color: var(--text-primary);
     margin: 0;
 }
@@ -143,6 +143,15 @@ header h1 {
     font-size: 0.95rem;
     color: var(--text-secondary);
     margin-top: 0.5rem;
+}
+
+.subheader {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--primary-color);
+    margin-top: 0.25rem;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
 }
 
 /* Main Content Area with Sidebar */


### PR DESCRIPTION
This PR addresses issue #2 by:

- Making the header bolder (font-weight 700 → 900)
- Adding "Course materials ROCK!!" subheader with blue primary color styling

Generated with [Claude Code](https://claude.ai/code)